### PR TITLE
Update ESLint dependencies for next major release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@socketsecurity/eslint-config",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "license": "MIT",
   "description": "The Socket ESLint config. Based on standard",
   "author": {
@@ -14,7 +14,7 @@
     "url": "git://github.com/SocketDev/eslint-config.git"
   },
   "engines": {
-    "node": "^14.18.0 || >=16.0.0"
+    "node": "^16.10.0 || >=18.0.0"
   },
   "main": "index.js",
   "files": [
@@ -28,36 +28,36 @@
     "prepare": "husky install"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.56.0",
-    "@typescript-eslint/parser": "^5.36.2",
-    "eslint": "^8.36.0",
-    "eslint-config-standard": "^17.0.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.3",
+    "@typescript-eslint/parser": "^6.7.3",
+    "eslint": "^8.50.0",
+    "eslint-config-standard": "^17.1.0",
     "eslint-config-standard-jsx": "^11.0.0",
-    "eslint-import-resolver-typescript": "^3.5.3",
-    "eslint-plugin-import": "^2.26.0",
-    "eslint-plugin-jsdoc": "^40.0.0",
-    "eslint-plugin-n": "^15.3.0",
+    "eslint-import-resolver-typescript": "^3.6.1",
+    "eslint-plugin-import": "^2.28.1",
+    "eslint-plugin-jsdoc": "^46.8.2",
+    "eslint-plugin-n": "^16.1.0",
     "eslint-plugin-promise": "^6.1.1",
-    "eslint-plugin-react": "^7.31.9",
+    "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",
     "husky": "^8.0.1",
     "installed-check": "^6.0.4",
     "typescript": "^5.0.2"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^5.56.0",
-    "@typescript-eslint/parser": "^5.36.2",
-    "eslint": "^8.36.0",
+    "@typescript-eslint/eslint-plugin": "^6.7.3",
+    "@typescript-eslint/parser": "^6.7.3",
+    "eslint": "^8.50.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",
     "eslint-import-resolver-typescript": "^3.5.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jsdoc": "^40.0.0",
-    "eslint-plugin-n": "^15.3.0",
+    "eslint-plugin-n": "^16.1.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.31.9",
     "eslint-plugin-react-hooks": "^4.6.0",
-    "eslint-plugin-unicorn": "^45.0.2",
+    "eslint-plugin-unicorn": "^48.0.1",
     "typescript": "*"
   }
 }


### PR DESCRIPTION
This PR updates the used ESLint dependencies and peerDependencies of this config. This will coincide with a major release due to a change in the supported Node.js versions / major version bumps of `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin`.