### PR TITLE
Ensure rule values are deep copied

### DIFF
--- a/lib/standard-eslint-ts.js
+++ b/lib/standard-eslint-ts.js
@@ -7,14 +7,6 @@ const standard = require('eslint-config-standard')
 
 const deepCopy = typeof structuredClone === 'function' ? structuredClone : x => JSON.parse(JSON.stringify(x))
 
-function deepCopyRuleValue (ruleValue) {
-  if (!Array.isArray(ruleValue)) {
-    // Case: rule value is a primitive (e.g., `1`, `"off"`, `"error"`)
-    return ruleValue
-  }
-  return deepCopy(ruleValue)
-}
-
 const neededChanges = {}
 const newChanges = {}
 
@@ -24,18 +16,18 @@ for (const ruleId in rules) {
     if (standard.rules[ruleId]) {
       neededChanges[ruleId] = 'off'
       if (ruleId !== 'dot-notation') {
-        newChanges['@typescript-eslint/' + ruleId] = deepCopyRuleValue(standard.rules[ruleId])
+        newChanges['@typescript-eslint/' + ruleId] = standard.rules[ruleId]
       }
     }
   }
 }
 
-const config = {
+const config = deepCopy({
   extends: ['standard', 'standard-jsx'],
   rules: {
     ...neededChanges,
     ...newChanges
   }
-}
+})
 
 module.exports = config

--- a/lib/standard-eslint-ts.js
+++ b/lib/standard-eslint-ts.js
@@ -5,12 +5,14 @@
 const { rules } = require('@typescript-eslint/eslint-plugin')
 const standard = require('eslint-config-standard')
 
+const deepCopy = typeof structuredClone === 'function' ? structuredClone : x => JSON.parse(JSON.stringify(x))
+
 function deepCopyRuleValue (ruleValue) {
   if (!Array.isArray(ruleValue)) {
     // Case: rule value is a primitive (e.g., `1`, `"off"`, `"error"`)
     return ruleValue
   }
-  return structuredClone(ruleValue)
+  return deepCopy(ruleValue)
 }
 
 const neededChanges = {}

--- a/lib/standard-eslint-ts.js
+++ b/lib/standard-eslint-ts.js
@@ -5,6 +5,14 @@
 const { rules } = require('@typescript-eslint/eslint-plugin')
 const standard = require('eslint-config-standard')
 
+function deepCopyRuleValue (ruleValue) {
+  if (!Array.isArray(ruleValue)) {
+    // Case: rule value is a primitive (e.g., `1`, `"off"`, `"error"`)
+    return ruleValue
+  }
+  return JSON.parse(JSON.stringify(ruleValue))
+}
+
 const neededChanges = {}
 const newChanges = {}
 
@@ -14,7 +22,7 @@ for (const ruleId in rules) {
     if (standard.rules[ruleId]) {
       neededChanges[ruleId] = 'off'
       if (ruleId !== 'dot-notation') {
-        newChanges['@typescript-eslint/' + ruleId] = standard.rules[ruleId]
+        newChanges['@typescript-eslint/' + ruleId] = deepCopyRuleValue(standard.rules[ruleId])
       }
     }
   }

--- a/lib/standard-eslint-ts.js
+++ b/lib/standard-eslint-ts.js
@@ -10,7 +10,7 @@ function deepCopyRuleValue (ruleValue) {
     // Case: rule value is a primitive (e.g., `1`, `"off"`, `"error"`)
     return ruleValue
   }
-  return JSON.parse(JSON.stringify(ruleValue))
+  return structuredClone(ruleValue)
 }
 
 const neededChanges = {}


### PR DESCRIPTION
Currently, if one mutates the configuration of one of the base rules, the corresponding `@typescript-eslint/*` rule may be changed as well and vice versa. This PR ensures that rule values are deep-copied.